### PR TITLE
Etag was not added on the response header.

### DIFF
--- a/m10-lesson1/um-webapp/src/main/java/com/baeldung/um/spring/UmWebConfig.java
+++ b/m10-lesson1/um-webapp/src/main/java/com/baeldung/um/spring/UmWebConfig.java
@@ -25,7 +25,7 @@ public class UmWebConfig extends WebMvcConfigurerAdapter {
     public FilterRegistrationBean someFilterRegistration() {
         final FilterRegistrationBean registration = new FilterRegistrationBean();
         registration.setFilter(etagFilter());
-        registration.addUrlPatterns("/api/*");
+        registration.addUrlPatterns("/*");
         registration.setName("etagFilter");
         registration.setOrder(1);
         return registration;


### PR DESCRIPTION
With this change the Etag header is added to the response header.
Based on the path in application.properties: server.servlet.contextPath=/um-webapp/api