### PR TITLE
Fixed typos in the *name* elements to correspond with the lesson 2

### DIFF
--- a/m1-lesson2-start/common/pom.xml
+++ b/m1-lesson2-start/common/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<name>common-l3-start</name>
+	<name>common-l2-start</name>
 	
 	<artifactId>common-m1-l2-start</artifactId>	
 

--- a/m1-lesson2-start/pom.xml
+++ b/m1-lesson2-start/pom.xml
@@ -1,8 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	
-	<description>REST with Spring Classes Module1-Lesson3-Start</description>
-	<name>user-management-parent-l3-start</name>
+	<description>REST with Spring Classes Module1-Lesson2-Start</description>
+	<name>user-management-parent-l2-start</name>
 		
 	<groupId>com.baeldung</groupId>
 	<artifactId>user-management-parent-m1-l2-start</artifactId>

--- a/m1-lesson2-start/um-webapp/pom.xml
+++ b/m1-lesson2-start/um-webapp/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
    
-    <name>um-webapp-l3-start</name>
+    <name>um-webapp-l2-start</name>
     <artifactId>um-webapp-m1-l2-start</artifactId>
     <packaging>jar</packaging>
         


### PR DESCRIPTION
I believe there is a mismatch between the content of the branch, folder name (intended for *module 1* and *lesson 2* of its beginning) and the value used for lesson in the `<name>` element in each `pom.xml` file.